### PR TITLE
[feat] 예매하기 [동시성 제어 구축]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/jticketing/aop/RedisAspect.java
+++ b/src/main/java/com/project/jticketing/aop/RedisAspect.java
@@ -1,0 +1,38 @@
+package com.project.jticketing.aop;
+
+import com.project.jticketing.config.redis.LockService;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RedisAspect {
+
+    private final LockService lockService;
+
+    @Pointcut("execution(* com.project.jticketing.domain.reservation.service.ReservationService.reserveSeatWithRedisWithAop(..))")
+    public void redisPointcut() {}
+
+    @Around("redisPointcut()")
+    public Object handleRedisLock(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        Long eventId = (Long) args[1];
+        Long seatNum = (Long) args[2];
+        String redisKey = "event:" + eventId + ":seat:" + seatNum;
+
+        if (lockService.tryLock(redisKey)) {
+            try {
+                return joinPoint.proceed();
+            } finally {
+                lockService.unlock(redisKey);
+            }
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/project/jticketing/config/redis/LockService.java
+++ b/src/main/java/com/project/jticketing/config/redis/LockService.java
@@ -1,0 +1,31 @@
+package com.project.jticketing.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LockService {
+
+    private final RedisLockRepository redisLockRepository;
+
+    // 락을 시도
+    public boolean tryLock(String key) {
+        return redisLockRepository.lock(key);
+    }
+
+    // 락 해제
+    public void unlock(String key) {
+        redisLockRepository.unlock(key);
+    }
+
+    // 상태 조회
+    public String getStatus(String key) {
+        return redisLockRepository.getStatus(key);
+    }
+
+    // 상태 설정
+    public void setStatus(String key, String status) {
+        redisLockRepository.setStatus(key, status);
+    }
+}

--- a/src/main/java/com/project/jticketing/config/redis/RedisConfig.java
+++ b/src/main/java/com/project/jticketing/config/redis/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.project.jticketing.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("localhost", 6379);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
+        return template;
+    }
+}

--- a/src/main/java/com/project/jticketing/config/redis/RedisLockRepository.java
+++ b/src/main/java/com/project/jticketing/config/redis/RedisLockRepository.java
@@ -1,0 +1,34 @@
+package com.project.jticketing.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Repository
+public class RedisLockRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Boolean lock(String key) {
+        return redisTemplate
+                .opsForValue()
+                .setIfAbsent(key, "lock", Duration.ofMillis(3000));
+    }
+
+    public Boolean unlock(String key) {
+        return redisTemplate.delete(key.toString());
+    }
+
+    // 상태 조회
+    public String getStatus(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    // 상태 설정
+    public void setStatus(String key, String status) {
+        redisTemplate.opsForValue().set(key, status);
+    }
+}

--- a/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
@@ -1,4 +1,31 @@
 package com.project.jticketing.domain.reservation.controller;
 
+import com.project.jticketing.config.security.UserDetailsImpl;
+import com.project.jticketing.domain.reservation.dto.request.ReservationRequestDTO;
+import com.project.jticketing.domain.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping("/event/{eventId}")
+    public ResponseEntity<Boolean> reservationSeat(
+            @AuthenticationPrincipal UserDetailsImpl authUser,
+            @PathVariable Long eventId,
+            @RequestBody ReservationRequestDTO reservationRequestDTO ) {
+
+        return new ResponseEntity<Boolean>(
+                reservationService.reserveSeatWithRedis(authUser,eventId,reservationRequestDTO.getSeatNum()),
+                HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
@@ -24,7 +24,7 @@ public class ReservationController {
             @RequestBody ReservationRequestDTO reservationRequestDTO ) {
 
         return new ResponseEntity<Boolean>(
-                reservationService.reserveSeatWithRedis(authUser,eventId,reservationRequestDTO.getSeatNum()),
+                reservationService.reserveSeatWithRedisWithAop(authUser,eventId,reservationRequestDTO.getSeatNum()),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/com/project/jticketing/domain/reservation/dto/request/ReservationRequestDTO.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/dto/request/ReservationRequestDTO.java
@@ -1,4 +1,12 @@
 package com.project.jticketing.domain.reservation.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
 public class ReservationRequestDTO {
+    long seatNum;
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/entity/Reservation.java
@@ -1,12 +1,18 @@
 package com.project.jticketing.domain.reservation.entity;
 
-import com.project.jticketing.domain.concert.entity.Concert;
+import com.project.jticketing.domain.event.entity.Event;
 import com.project.jticketing.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Setter
+@NoArgsConstructor
 @Table(name = "reservations")
 public class Reservation {
     @Id
@@ -22,6 +28,13 @@ public class Reservation {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "concert_id", nullable = false)
-    private Concert concert;
+    @JoinColumn(name = "events_id", nullable = false)
+    private Event event;
+
+    public Reservation(Long seatNum, LocalDateTime reservationDate, User user, Event event) {
+        this.seatNum = seatNum;
+        this.reservationDate = reservationDate;
+        this.user = user;
+        this.event = event;
+    }
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
@@ -3,5 +3,10 @@ package com.project.jticketing.domain.reservation.repository;
 import com.project.jticketing.domain.reservation.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Optional<Reservation> findByEventIdAndSeatNum(Long eventId, Long seatNum);
+
+    long countByEventIdAndSeatNum(Long eventId, Long seatNum);
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
@@ -1,0 +1,59 @@
+package com.project.jticketing.domain.reservation.service;
+
+import com.project.jticketing.config.redis.LockService;
+import com.project.jticketing.config.security.UserDetailsImpl;
+import com.project.jticketing.domain.event.repository.EventRepository;
+import com.project.jticketing.domain.reservation.entity.Reservation;
+import com.project.jticketing.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    private final LockService lockService;
+
+    private final EventRepository eventRepository;
+
+    @Transactional
+    public boolean reserveSeatWithoutRedis(UserDetailsImpl authUser, Long eventId, Long seatNum) {
+        // DB에서 해당 좌석의 예약 상태 확인
+        Optional<Reservation> dbReservationOpt = reservationRepository.findByEventIdAndSeatNum(eventId, seatNum);
+
+        // 이미 예약된 좌석은 예약 불가
+        if (dbReservationOpt.isPresent()) {
+            return false;
+        }
+
+        // 데이터베이스에 예약 저장
+        Reservation reservation = new Reservation();
+        reservation.setSeatNum(seatNum);
+        reservation.setReservationDate(LocalDateTime.now());
+        reservation.setUser(authUser.getUser());
+        reservation.setEvent(eventRepository.findById(eventId).orElseThrow(() -> new IllegalArgumentException("Event not found")));
+        reservationRepository.save(reservation);
+
+        return true;
+    }
+
+    public boolean reserveSeatWithRedis(UserDetailsImpl authUser, Long eventId, Long seatNum) {
+        String redisKey = "event:" + eventId + ":seat:" + seatNum;
+        if (lockService.tryLock(redisKey)) {
+            System.out.println("Locking흭득 - " + redisKey);
+            boolean result = reserveSeatWithoutRedis(authUser, eventId, seatNum);
+            System.out.println("Locking해제 - " + redisKey);
+            lockService.unlock(redisKey);
+            return result;
+        }
+        return false;
+
+    }
+
+}

--- a/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
@@ -53,7 +53,10 @@ public class ReservationService {
             return result;
         }
         return false;
+    }
 
+    public boolean reserveSeatWithRedisWithAop(UserDetailsImpl authUser, Long eventId, Long seatNum) {
+        return reserveSeatWithoutRedis(authUser, eventId, seatNum);
     }
 
 }

--- a/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceMockTest.java
+++ b/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceMockTest.java
@@ -1,0 +1,186 @@
+package com.project.jticketing.domain.reservation.service;
+
+import com.project.jticketing.config.redis.LockService;
+import com.project.jticketing.config.redis.RedisLockRepository;
+import com.project.jticketing.config.security.UserDetailsImpl;
+import com.project.jticketing.domain.concert.repository.ConcertRepository;
+import com.project.jticketing.domain.event.entity.Event;
+import com.project.jticketing.domain.event.repository.EventRepository;
+import com.project.jticketing.domain.place.entity.Place;
+import com.project.jticketing.domain.place.repository.PlaceRepository;
+import com.project.jticketing.domain.reservation.entity.Reservation;
+import com.project.jticketing.domain.reservation.repository.ReservationRepository;
+import com.project.jticketing.domain.user.entity.User;
+import com.project.jticketing.domain.user.enums.UserRole;
+import com.project.jticketing.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ReservationServiceMockTest {
+
+    @Mock
+    private LockService lockService;
+
+    @Mock
+    private ReservationRepository reservationRepository;  // Mock 객체
+
+    @Mock
+    private EventRepository eventRepository;  // Mock 객체
+
+    @Mock
+    private RedisLockRepository redisLockRepository;
+
+    @Mock
+    private UserRepository userRepository;  // Mock 객체
+
+    @InjectMocks
+    private ReservationService reservationService;  // ReservationService 객체에 Mock 객체가 주입됨
+
+    private User testUser;
+    private Event testEvent;
+    private List<User> userList;
+
+    private final int NUMBER_OF_EXCURSIONS = 100;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 생성
+        testUser = new User("testuser6@example.com", "!Test1234", "tester", "address", "010-0000-0000", UserRole.USER);
+        userList = new ArrayList<>();
+
+        for (int i = 0; i < NUMBER_OF_EXCURSIONS; i++) {
+            userList.add(
+                    new User("teruser" + i + "@example.com",
+                            "!Test1234",
+                            "tester",
+                            "address",
+                            "010-0000-0000",
+                            UserRole.USER)
+            );
+        }
+
+
+        testEvent = Event.builder().id(1L).build();
+
+        when(lockService.tryLock(anyString()))
+                .thenReturn(true)
+                .thenReturn(false);
+
+
+        when(eventRepository.findById(any())).thenReturn(Optional.of(testEvent));
+        when(reservationRepository.save(any(Reservation.class))).thenReturn(new Reservation(1L, LocalDateTime.now(), testUser, testEvent));
+    }
+
+    @Test
+    @DisplayName("예약 단건 요청")
+    void reserveSeat() {
+        // Given
+        Long seatNum = 1L;
+
+        // UserDetailsImpl을 생성하여 인증된 사용자로 테스트
+        UserDetailsImpl authUser = new UserDetailsImpl(testUser);
+
+        // When
+        boolean result = reservationService.reserveSeatWithRedis(authUser, testEvent.getId(), seatNum);
+
+        // Then
+        assertThat(result).isTrue();  // 예약이 성공했는지 확인
+        verify(reservationRepository, times(1)).save(any(Reservation.class));  // save 메서드가 한 번 호출되었는지 확인
+    }
+
+    @Test
+    @DisplayName("예매 동시성 테스트(Redis미사용)")
+    void reserveSeat_withoutRedis_concurrentTest() throws InterruptedException {
+        // Given
+        final Long seatNum = 4L;
+
+        // 스레드 풀과 CyclicBarrier 설정
+        ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_EXCURSIONS);
+        CyclicBarrier barrier = new CyclicBarrier(NUMBER_OF_EXCURSIONS);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < NUMBER_OF_EXCURSIONS; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    barrier.await();  // 모든 스레드가 이 지점에 도달할 때까지 대기
+
+                    UserDetailsImpl authUser = new UserDetailsImpl(userList.get(index));
+                    boolean result = reservationService.reserveSeatWithoutRedis(authUser, testEvent.getId(), seatNum);  // 예매 시도
+
+                    System.out.println("Thread result: " + result);
+                    if(result){
+                        successCount.incrementAndGet();
+                    }
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+
+        assertThat(successCount.get()).isEqualTo(1);  // 하나의 예약만 성공해야 함
+    }
+
+
+    @Test
+    @DisplayName("예매 동시성 테스트(Redis사용)")
+    void reserveSeat_concurrentTest() throws InterruptedException {
+        // Given
+        final Long seatNum = 4L;
+
+        // 스레드 풀과 CyclicBarrier 설정
+        ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_EXCURSIONS);
+        CyclicBarrier barrier = new CyclicBarrier(NUMBER_OF_EXCURSIONS);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < NUMBER_OF_EXCURSIONS; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    barrier.await();  // 모든 스레드가 이 지점에 도달할 때까지 대기
+
+                    UserDetailsImpl authUser = new UserDetailsImpl(userList.get(index));
+                    boolean result = reservationService.reserveSeatWithRedis(authUser, testEvent.getId(), seatNum);  // 예매 시도
+
+                    System.out.println("Thread result: " + result);
+                    if(result){
+                        successCount.incrementAndGet();
+                    }
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+
+        assertThat(successCount.get()).isEqualTo(1);  // 하나의 예약만 성공해야 함
+    }
+}

--- a/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,173 @@
+package com.project.jticketing.domain.reservation.service;
+
+
+import com.project.jticketing.config.security.UserDetailsImpl;
+import com.project.jticketing.domain.concert.entity.Concert;
+import com.project.jticketing.domain.concert.repository.ConcertRepository;
+import com.project.jticketing.domain.event.entity.Event;
+import com.project.jticketing.domain.event.repository.EventRepository;
+import com.project.jticketing.domain.place.entity.Place;
+import com.project.jticketing.domain.place.repository.PlaceRepository;
+import com.project.jticketing.domain.reservation.entity.Reservation;
+import com.project.jticketing.domain.reservation.repository.ReservationRepository;
+import com.project.jticketing.domain.user.entity.User;
+import com.project.jticketing.domain.user.enums.UserRole;
+import com.project.jticketing.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ReservationServiceTest {
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ConcertRepository concertRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+    private Event testEvent;
+    private Place testPlace;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 및 이벤트 생성
+        testUser = userRepository.save(new User("testuser6@example.com", "!Test1234", "tester", "address", "010-0000-0000", UserRole.USER));
+
+        testPlace = new Place("aaa",100L);
+        testPlace = placeRepository.save(testPlace);
+
+        // 테스트 콘서트 생성
+        Concert concert = Concert.builder()
+                .title("testConcert")
+                .startTime("18:00")
+                .endTime("21:00")
+                .description("설명")
+                .price(50000L)
+                .place(testPlace)
+                .build();
+        concert = concertRepository.save(concert);
+
+        LocalDate concertDate = LocalDate.of(2024, 12, 25);
+
+//        testEvent = new Event(concertDate, concert);
+//        testEvent = eventRepository.save(testEvent);
+        testEvent = eventRepository.findById(40L).orElse(null);
+    }
+
+
+    @Test
+    void reserveSeatWithoutRedis_concurrentTest() throws InterruptedException {
+        final int numberOfThreads = 1;
+        final Long seatNum = 1L;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        // 모든 스레드가 시작할 때까지 대기하는 CyclicBarrier 설정
+        CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 모든 스레드가 이 지점에 도달할 때까지 대기
+                    barrier.await();
+
+                    UserDetailsImpl authUser = new UserDetailsImpl(testUser);
+                    boolean result = reservationService.reserveSeatWithoutRedis(authUser, testEvent.getId(), seatNum);
+                    System.out.println("Thread result: " + result);
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        // 스레드 작업이 완료될 때까지 기다리기
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        long reservationCount = reservationRepository.countByEventIdAndSeatNum(testEvent.getId(), seatNum);
+        assertThat(reservationCount).isEqualTo(1); // 하나의 예약만 성공해야 함
+    }
+
+    @Test
+    @DisplayName("예매 동시성 테스트")
+    void reserveSeatWithRedis_concurrentTest() throws InterruptedException {
+        final int numberOfThreads = 10;
+        final Long seatNum = 4L;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        // 모든 스레드가 시작할 때까지 대기하는 CyclicBarrier 설정
+        CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 모든 스레드가 이 지점에 도달할 때까지 대기
+                    barrier.await();
+
+                    UserDetailsImpl authUser = new UserDetailsImpl(testUser);
+
+                    boolean result = reservationService.reserveSeatWithRedis(authUser, testEvent.getId(), seatNum);
+                    System.out.println("Thread result: " + result);
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        // 스레드 작업이 완료될 때까지 기다리기
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        long reservationCount = reservationRepository.countByEventIdAndSeatNum(40L, seatNum);
+
+
+
+        System.out.println("seatNum : " + seatNum);
+        System.out.println(reservationCount);
+
+
+        assertThat(reservationCount).isEqualTo(1); // 하나의 예약만 성공해야 함
+    }
+
+
+    @Test
+    @DisplayName("예매 단건 요청")
+    void reserveSeatWithRedis() throws InterruptedException {
+
+        UserDetailsImpl authUser = new UserDetailsImpl(testUser);
+        boolean result = reservationService.reserveSeatWithRedis(authUser, testEvent.getId(), 1L);
+
+        assertThat(result).isTrue(); // 예약이 성공했는지 확인
+
+        // 데이터베이스에서 방금 저장한 예약 확인
+        Optional<Reservation> savedReservation = reservationRepository.findByEventIdAndSeatNum(testEvent.getId(), 1L);
+
+        long reservationCount = reservationRepository.countByEventIdAndSeatNum(testEvent.getId(), 1L);
+        assertThat(reservationCount).isEqualTo(1); // 하나의 예약만 성공해야 함
+
+        assertThat(savedReservation).isPresent();
+        assertThat(savedReservation.get().getSeatNum()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
### **필수 구현 기능**

-   **동시성 이슈를 검증할 수 있는 테스트 코드 작성**
    - 여러 `Thread` 가 동시에 동시성 이슈가 발생하는 메소드를 호출하는 시나리오를 토대로 테스트 코드를 작성
        - `ExecutorService` , `CyclicBarrier`  활용가능
```
    @Test
    @DisplayName("예매 동시성 테스트(Redis미사용)")
    void test() throws InterruptedException {
        ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_EXCURSIONS);
        CyclicBarrier barrier = new CyclicBarrier(NUMBER_OF_EXCURSIONS);

        for (int i = 0; i < NUMBER_OF_EXCURSIONS; i++) {
            executorService.submit(() -> {
                try {
                    barrier.await();  
                    boolean result = //실제 예매서비스 실행
                } catch (Exception e) {
                    e.printStackTrace();
                }
            });
        }
        executorService.shutdown();
        executorService.awaitTermination(1, TimeUnit.MINUTES);
    }
```
위의 구조를 가진 테스트 코드를 작성하여 서비스 코드에 대한 동시성 처리 테스트를 확인하도록 구현하였습니다.



-  **Redis 를 이용해 Lock 을 구현함으로써 동시성 이슈 제어**
    - `Lettuce` 를 이용해 Redis Lock 구현
```
    @Bean
    public RedisConnectionFactory redisConnectionFactory() {
        return new LettuceConnectionFactory("localhost", 6379);
    }
```
1) Lock 획득에 실패했을 때 어떻게 할 것인가?
 원래 Lettuce는 Spin Lock방식을 구현하여 시스템 자원에 대한 요구량이 많아질 수 있지만 예매하기 기능에 대한 동시성 제어에서는 Spin Lock방식이 불필요하여 Lock에 대한 권한을 얻지못한 요청은 모두 종료되게 구현하였습니다.

2) Redis 를 이용해 Lock 을 구현한 이유는 무엇일까?
 Redis를 이용해 Lock을 구현한 이유는 DB는 실제 하드에 저장되는 방식이고 Redis는 인메모리 방식으로 데이터 접근에 대한 속도 차이가 우월하여 많은 요청을 동시에 처리하려고 할 때에는 Redis같은 인 메모리 방식이 우월하여 Redis로 구축하였습니다.

3) Redis 에서 Lock 을 걸때 Key 로 어떤 값을 사용했고, 왜 해당 Key 를 이용해 Lock 을 만들었을까?
```
String redisKey = "event:" + eventId + ":seat:" + seatNum;
```
현재 redis에서 키를 위와 같은 방식으로 생성하였는데, 위와 같이 한 이유는 식별이 쉽고, 간단하게 해당 이벤트에 대한 자리정보를 쉽게 접근할 수 있기 때문입니다.




### 선택 구현 기능

- [ ]  **Lock 을 AOP 방식으로 적용할 수 있도록 코드 리팩토링**
    - `Spring AOP`
```
기존코드
    public boolean reserveSeatWithRedis(UserDetailsImpl authUser, Long eventId, Long seatNum) {
        String redisKey = "event:" + eventId + ":seat:" + seatNum;
        if (lockService.tryLock(redisKey)) {
            System.out.println("Locking흭득 - " + redisKey);
            boolean result = reserveSeatWithoutRedis(authUser, eventId, seatNum);
            System.out.println("Locking해제 - " + redisKey);
            lockService.unlock(redisKey);
            return result;
        }
        return false;
    }
```
```
변경 코드
    public boolean reserveSeatWithRedisWithAop(UserDetailsImpl authUser, Long eventId, Long seatNum) {
        return reserveSeatWithoutRedis(authUser, eventId, seatNum);
    }
```
```
@Aspect
@Component
@RequiredArgsConstructor
public class RedisAspect {

    private final LockService lockService;

    @Pointcut("execution(* com.project.jticketing.domain.reservation.service.ReservationService.reserveSeatWithRedisWithAop(..))")
    public void redisPointcut() {}

    @Around("redisPointcut()")
    public Object handleRedisLock(ProceedingJoinPoint joinPoint) throws Throwable {
        Object[] args = joinPoint.getArgs();
        Long eventId = (Long) args[1];
        Long seatNum = (Long) args[2];
        String redisKey = "event:" + eventId + ":seat:" + seatNum;

        if (lockService.tryLock(redisKey)) {
            try {
                return joinPoint.proceed();
            } finally {
                lockService.unlock(redisKey);
            }
        } else {
            return false;
        }
    }
}

```
위와 같이 구현하여 Service에서 처리하던 로킹을 Aop로 분리하여 처리하도록 구현


# 구현할 항목
### 심화 구현 기능

- [ ]  **Redis 대신 MySQL 을 이용해 Lock 구현**
   - 비관적락
   - Excrusive Lock 


- [ ]  **`Redisson` 을 이용한 Redis Lock 개발**
    - `Lettuce` 가 아니라 `Redisson` 을 사용한 이유를 설명할 수 있어야한다.