### PR TITLE
Feat/x-lock

### DIFF
--- a/src/main/java/com/project/jticketing/aop/RedisAspect.java
+++ b/src/main/java/com/project/jticketing/aop/RedisAspect.java
@@ -1,3 +1,4 @@
+/*
 package com.project.jticketing.aop;
 
 import com.project.jticketing.config.redis.LockService;
@@ -36,3 +37,4 @@ public class RedisAspect {
         }
     }
 }
+*/

--- a/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
@@ -3,6 +3,7 @@ package com.project.jticketing.domain.reservation.controller;
 import com.project.jticketing.config.security.UserDetailsImpl;
 import com.project.jticketing.domain.reservation.dto.request.ReservationRequestDTO;
 import com.project.jticketing.domain.reservation.service.ReservationService;
+import com.project.jticketing.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,8 +24,10 @@ public class ReservationController {
             @PathVariable Long eventId,
             @RequestBody ReservationRequestDTO reservationRequestDTO ) {
 
+        User user = authUser.getUser();
+
         return new ResponseEntity<Boolean>(
-                reservationService.reserveSeatWithRedisWithAop(authUser,eventId,reservationRequestDTO.getSeatNum()),
+                reservationService.exclusiveLock(user,eventId,reservationRequestDTO.getSeatNum()),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
@@ -1,7 +1,11 @@
 package com.project.jticketing.domain.reservation.repository;
 
+import com.project.jticketing.domain.event.entity.Event;
 import com.project.jticketing.domain.reservation.entity.Reservation;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -9,4 +13,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     Optional<Reservation> findByEventIdAndSeatNum(Long eventId, Long seatNum);
 
     long countByEventIdAndSeatNum(Long eventId, Long seatNum);
+
+
+    @Query("select r from Reservation r where r.event = :event and r.seatNum = :seatNum")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    boolean existByEventAndSeatNum(Event event, long seatNum);
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
@@ -17,5 +17,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("select r from Reservation r where r.event = :event and r.seatNum = :seatNum")
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    boolean existByEventAndSeatNum(Event event, long seatNum);
+    Optional<Reservation> findByEventAndSeatNum(Event event, long seatNum);
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
@@ -2,9 +2,11 @@ package com.project.jticketing.domain.reservation.service;
 
 import com.project.jticketing.config.redis.LockService;
 import com.project.jticketing.config.security.UserDetailsImpl;
+import com.project.jticketing.domain.event.entity.Event;
 import com.project.jticketing.domain.event.repository.EventRepository;
 import com.project.jticketing.domain.reservation.entity.Reservation;
 import com.project.jticketing.domain.reservation.repository.ReservationRepository;
+import com.project.jticketing.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,4 +61,16 @@ public class ReservationService {
         return reserveSeatWithoutRedis(authUser, eventId, seatNum);
     }
 
+    @Transactional
+    public Boolean exclusiveLock(User user, Long eventId, long seatNum) {
+        Event event = eventRepository.findById(eventId).orElseThrow(() -> new IllegalArgumentException("Event not found"));
+
+        if (reservationRepository.existByEventAndSeatNum(event, seatNum)) {
+            throw new IllegalStateException("해당 좌석에 대한 예매가 진행 중입니다");
+        }
+
+        Reservation reservation = new Reservation(seatNum, LocalDateTime.now(), user, event);
+        reservationRepository.save(reservation);
+        return true;
+    }
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
@@ -63,9 +63,14 @@ public class ReservationService {
 
     @Transactional
     public Boolean exclusiveLock(User user, Long eventId, long seatNum) {
-        Event event = eventRepository.findById(eventId).orElseThrow(() -> new IllegalArgumentException("Event not found"));
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Event not found"));
 
-        if (reservationRepository.existByEventAndSeatNum(event, seatNum)) {
+        // 동시성 문제 해결을 위해 findOne with Lock
+        Optional<Reservation> existingReservation = reservationRepository
+                .findByEventAndSeatNum(event, seatNum);
+
+        if (existingReservation.isPresent()) {
             throw new IllegalStateException("해당 좌석에 대한 예매가 진행 중입니다");
         }
 

--- a/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceTest.java
@@ -53,7 +53,7 @@ public class ReservationServiceTest {
     @BeforeEach
     void setUp() {
         // 테스트용 사용자 및 이벤트 생성
-        testUser = userRepository.save(new User("testuser6@example.com", "!Test1234", "tester", "address", "010-0000-0000", UserRole.USER));
+        testUser = userRepository.save(new User("testuser3@example.com", "!Test1234", "tester", "address", "010-0000-0000", UserRole.USER));
 
         testPlace = new Place("aaa",100L);
         testPlace = placeRepository.save(testPlace);
@@ -167,5 +167,43 @@ public class ReservationServiceTest {
 
         assertThat(savedReservation).isPresent();
         assertThat(savedReservation.get().getSeatNum()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("배타적 락 테스트")
+    void testExclusiveLock() throws InterruptedException {
+        final int numberOfThreads = 1;
+        final Long seatNum = 1L;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        // 모든 스레드가 시작할 때까지 대기하는 CyclicBarrier 설정
+        CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 모든 스레드가 이 지점에 도달할 때까지 대기
+                    barrier.await();
+
+                    boolean result = reservationService.exclusiveLock(testUser, testEvent.getId(), seatNum);
+                    System.out.println("Thread result: " + result);
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        // 스레드 작업이 완료될 때까지 기다리기
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        long reservationCount = reservationRepository.countByEventIdAndSeatNum(testEvent.getId(), seatNum);
+        assertThat(reservationCount).isEqualTo(1); // 하나의 예약만 성공해야 함
+
+        // 저장된 Reservation 검증
+        Optional<Reservation> savedReservation = reservationRepository.findByEventIdAndSeatNum(testEvent.getId(), seatNum);
+
+        assertThat(savedReservation).isPresent(); // 예약이 존재하는지 확인
     }
 }


### PR DESCRIPTION
레포지토리 
 
 ```
    @Query("select r from Reservation r where r.event = :event and r.seatNum = :seatNum")
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    Optional<Reservation> findByEventAndSeatNum(Event event, long seatNum);
 ```

JPQL이나 JPA 제공 메서드에 애노테이션을 활용해 간단히 Exclusive Lock 구현 가능
 
 -----
 
 서비스

```
    @Transactional
    public Boolean exclusiveLock(User user, Long eventId, long seatNum) {
        Event event = eventRepository.findById(eventId)
                .orElseThrow(() -> new IllegalArgumentException("Event not found"));

        // 동시성 문제 해결을 위해 findOne with Lock
        Optional<Reservation> existingReservation = reservationRepository
                .findByEventAndSeatNum(event, seatNum);

        if (existingReservation.isPresent()) {
            throw new IllegalStateException("해당 좌석에 대한 예매가 진행 중입니다");
        }

        Reservation reservation = new Reservation(seatNum, LocalDateTime.now(), user, event);
        reservationRepository.save(reservation);
        return true;
    }
```    
 
#### 배타적 락의 장단점 : 


