### PR TITLE
Feat/19 - JPA Lock 구현

### DIFF
--- a/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/controller/ReservationController.java
@@ -17,15 +17,25 @@ public class ReservationController {
 
     private final ReservationService reservationService;
 
+    // @PostMapping("/event/{eventId}")
+    // public ResponseEntity<Boolean> reservationSeat(
+    //         @AuthenticationPrincipal UserDetailsImpl authUser,
+    //         @PathVariable Long eventId,
+    //         @RequestBody ReservationRequestDTO reservationRequestDTO ) {
+    //
+    //     return new ResponseEntity<Boolean>(
+    //             reservationService.reserveSeatWithRedisWithAop(authUser,eventId,reservationRequestDTO.getSeatNum()),
+    //             HttpStatus.OK);
+    // }
+
     @PostMapping("/event/{eventId}")
     public ResponseEntity<Boolean> reservationSeat(
-            @AuthenticationPrincipal UserDetailsImpl authUser,
-            @PathVariable Long eventId,
-            @RequestBody ReservationRequestDTO reservationRequestDTO ) {
+        @AuthenticationPrincipal UserDetailsImpl authUser,
+        @PathVariable Long eventId,
+        @RequestBody ReservationRequestDTO reservationRequestDTO ) {
 
         return new ResponseEntity<Boolean>(
-                reservationService.reserveSeatWithRedisWithAop(authUser,eventId,reservationRequestDTO.getSeatNum()),
-                HttpStatus.OK);
+            reservationService.reserveSeatWithJPALock(authUser,eventId,reservationRequestDTO.getSeatNum()),
+            HttpStatus.OK);
     }
-
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
@@ -3,6 +3,7 @@ package com.project.jticketing.domain.reservation.repository;
 import com.project.jticketing.domain.reservation.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -13,6 +14,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     long countByEventIdAndSeatNum(Long eventId, Long seatNum);
 
+	@Query("SELECT r FROM Reservation r WHERE r.event.id = :eventId AND r.seatNum = :seatNum")
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<Reservation> findByEventIdAndSeatNumWithLock(Long eventId, Long seatNum);
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/repository/ReservationRepository.java
@@ -2,11 +2,17 @@ package com.project.jticketing.domain.reservation.repository;
 
 import com.project.jticketing.domain.reservation.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     Optional<Reservation> findByEventIdAndSeatNum(Long eventId, Long seatNum);
 
     long countByEventIdAndSeatNum(Long eventId, Long seatNum);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<Reservation> findByEventIdAndSeatNumWithLock(Long eventId, Long seatNum);
 }

--- a/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/project/jticketing/domain/reservation/service/ReservationService.java
@@ -7,6 +7,7 @@ import com.project.jticketing.domain.reservation.entity.Reservation;
 import com.project.jticketing.domain.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -59,6 +60,9 @@ public class ReservationService {
         return reserveSeatWithoutRedis(authUser, eventId, seatNum);
     }
 
+    // timeout 속성을 설정하면 트랜잭션이 일정 시간 이상 실행되지 않으면 자동으로 롤백됩니다. 이를 통해 교착 상태를 방지하거나 해결할 수 있습니다.
+    // 교착 상태로 인해 트랜잭션이 일정 시간 이상 대기할 경우, 3초 이상 대기하지 않도록 설정함으로써 시스템이 교착 상태에 빠지지 않도록 합니다.
+    @Transactional(timeout = 3)
     public boolean reserveSeatWithJPALock(UserDetailsImpl authUser, Long eventId, Long seatNum) {
         // DB에서 해당 좌석의 예약 상태 확인
         Optional<Reservation> dbReservationOpt = reservationRepository.findByEventIdAndSeatNumWithLock(eventId, seatNum);

--- a/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceTestJPALock.java
+++ b/src/test/java/com/project/jticketing/domain/reservation/service/ReservationServiceTestJPALock.java
@@ -1,0 +1,94 @@
+package com.project.jticketing.domain.reservation.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.jticketing.config.security.UserDetailsImpl;
+import com.project.jticketing.domain.concert.entity.Concert;
+import com.project.jticketing.domain.event.entity.Event;
+import com.project.jticketing.domain.event.repository.EventRepository;
+import com.project.jticketing.domain.place.entity.Place;
+import com.project.jticketing.domain.place.repository.PlaceRepository;
+import com.project.jticketing.domain.reservation.entity.Reservation;
+import com.project.jticketing.domain.reservation.repository.ReservationRepository;
+import com.project.jticketing.domain.user.entity.User;
+import com.project.jticketing.domain.user.enums.UserRole;
+import com.project.jticketing.domain.user.repository.UserRepository;
+
+@SpringBootTest
+class ReservationServiceTestJPALock {
+
+	@Autowired
+	private ReservationService reservationService; // 예약 서비스
+	@Autowired
+	private EventRepository eventRepository;
+	@Autowired
+	private ReservationRepository reservationRepository;
+	@Autowired
+	private UserRepository userRepository;
+
+	private Long eventId; // 테스트용 이벤트 ID
+
+	private User testUser;
+	private Event testEvent;
+	private Place testPlace;
+	private UserDetailsImpl testUserDetails;
+
+	@Test
+	@Transactional
+	void reserveSeatWithJPALock() throws InterruptedException, BrokenBarrierException {
+		{
+			Long seatNum = 2L; // 테스트할 좌석 번호
+			int threadCount = 5; // 동시 실행할 스레드 수
+
+			// CyclicBarrier로 동시 시작점 조율
+			CyclicBarrier barrier = new CyclicBarrier(threadCount);
+
+			// 스레드 풀 설정
+			ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+			// 동시 예약 테스트 실행
+			for (int i = 1; i <= threadCount; i++) {
+				final int userId = i;
+				executorService.execute(() -> {
+					try {
+						barrier.await(); // 모든 스레드가 준비될 때까지 대기
+						User user = userRepository.findById((long)userId).orElseThrow(
+							() -> new RuntimeException("유저를 찾을 수 없습니다."));
+						testUserDetails = new UserDetailsImpl(user);
+						reservationService.reserveSeatWithJPALock(testUserDetails, 1L, seatNum);
+
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+				});
+			}
+
+			executorService.shutdown();
+			executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+			// 예약된 좌석 개수를 기존 방식으로 확인 (List로 변경된 메서드 사용)
+			reservationRepository.findByEventIdAndSeatNumWithLock(1L, seatNum);
+			// 예약된 좌석이 존재하면 성공한 예약 수는 1개여야 함
+			long reservationCount = reservationRepository.count();  // 예약 개수 확인
+			assertEquals(1, reservationCount);  // 기대한 개수와 비교
+		}
+	}
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게 수정했나보다 무엇을 왜 수정했는지 설명해주세요. -->
- JPA Lock 구현
- JPA Lock 테스트 코드 작성(통합 테스트로 진행)

```
//JPA Lock 설정
@Query("SELECT r FROM Reservation r WHERE r.event.id = :eventId AND r.seatNum = :seatNum")
@Lock(LockModeType.PESSIMISTIC_WRITE)
Optional<Reservation> findByEventIdAndSeatNumWithLock(Long eventId, Long seatNum);
```

## JPA락 장점
1. 데이터 무결성 보장
- JPA 락은 데이터베이스 자체에서 락을 관리하므로, 데이터 무결성을 매우 강력하게 보장, 비관적 락(Pessimistic Lock)은 트랜잭션 동안 

2. 설정 및 사용의 간단함
- JPA와 함께 사용할 경우, 어노테이션(@Lock, @Version)이나 메서드 기반으로 쉽게 락을 설정할 수 있다
- 별도의 Redis 설치나 추가적인 코드 구현이 필요하지 않는다

3. 트랜잭션과의 통합
- 데이터가 수정되기 전에 자동으로 충돌 여부를 확인(낙관적 락)하거나 트랜잭션 동안 다른 트랜잭션이 접근하지 못하게 보장(비관적 락).

4. 추가 시스템 의존성 없음
- Redis와 달리 별도의 캐시 시스템을 설치할 필요가 없고 JPA와 데이터베이스만으로 구현이 가능합니다.

## JPA락 단점
1. 성능 저하
- 비관적 락: 데이터베이스에서 지속적으로 락을 관리하므로 트랜잭션이 길어지거나 동시 요청이 많을 경우 성능이 크게 저하된다.
- 락 충돌이 잦을수록 대기 시간이 늘어나며, 처리 속도가 느려질 수 있다.

2. 교착 상태 (Deadlock)
- 여러 트랜잭션이 동시에 동일한 리소스를 요청할 경우 교착 상태(Deadlock)가 발생할 가능성이 높다.

3. 확장성 부족
- JPA 락은 데이터베이스 락에 의존하기 때문에 분산 시스템 환경에서는 적합하지 않다.

4. 락 경합 증가
- 데이터베이스의 락 경합이 많아질수록 응답 시간이 느려지고, 전체 시스템 성능이 저하된다.
